### PR TITLE
Exchange .textsize method invocation by .textlength

### DIFF
--- a/image_text_overlay.py
+++ b/image_text_overlay.py
@@ -45,7 +45,7 @@ class ImageTextOverlay:
         draw = ImageDraw.Draw(image)
 
         # Adjust x coordinate based on alignment
-        text_width, text_height = draw.textsize(text, font=loaded_font)
+        text_width = draw.textlength(text, font=loaded_font)
         if alignment == "center":
             x -= text_width // 2
         elif alignment == "right":


### PR DESCRIPTION
Since v10.0.0 (2023-07-01) of Pillow the method ImageDraw.textsize() has been removed.
I replaced the invocation of the method with an alternative using ImageDraw.textbbox() as described in the link of below

See https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods for more information